### PR TITLE
Feature added: Marquee track title

### DIFF
--- a/Radio SRF Player/StatusMenuController.swift
+++ b/Radio SRF Player/StatusMenuController.swift
@@ -61,6 +61,10 @@ class StatusMenuController: NSObject {
     }
     
     @IBAction func stopPlayback(_ sender: NSMenuItem) {
+        stopPlayer()
+    }
+    
+    func stopPlayer() {
         if avPlayer != nil {
             avPlayer.pause();
         }

--- a/Radio SRF Player/StatusMenuController.swift
+++ b/Radio SRF Player/StatusMenuController.swift
@@ -13,7 +13,7 @@ class StatusMenuController: NSObject {
     
     @IBOutlet weak var statusMenu: NSMenu!
     
-    let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+    let statusItem = NSStatusBar.system.statusItem(withLength: 120)
     
     var avPlayer: AVPlayer!
     var avPlayerItem: AVPlayerItem!
@@ -24,6 +24,7 @@ class StatusMenuController: NSObject {
         icon?.isTemplate = true // best for dark mode
         statusItem.image = icon
         statusItem.menu = statusMenu
+        statusItem.title = "Radio App"
  
     }
     

--- a/Radio SRF Player/StatusMenuController.swift
+++ b/Radio SRF Player/StatusMenuController.swift
@@ -16,6 +16,7 @@ class StatusMenuController: NSObject {
     let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     
     var avPlayer: AVPlayer!
+    var avPlayerItem: AVPlayerItem!
     
     override func awakeFromNib() {
         let icon = NSImage(named: NSImage.Name(rawValue: "statusIcon"))
@@ -56,7 +57,9 @@ class StatusMenuController: NSObject {
     
     func playRadio(radioUrl: String)
     {
-        avPlayer = AVPlayer.init(url: NSURL(string: radioUrl)! as URL)
+        avPlayerItem = AVPlayerItem(url: NSURL(string: radioUrl)! as URL)
+        
+        avPlayer = AVPlayer(playerItem: avPlayerItem)
         avPlayer.play()
     }
     

--- a/Radio SRF Player/StatusMenuController.swift
+++ b/Radio SRF Player/StatusMenuController.swift
@@ -31,34 +31,32 @@ class StatusMenuController: NSObject {
     }
     
     @IBAction func playRadioSRF1(_ sender: NSMenuItem) {
-        avPlayer = AVPlayer.init(url: NSURL(string: "http://stream.srg-ssr.ch/m/drs1/mp3_128")! as URL)
-        avPlayer.play()
+        playRadio(radioUrl: "http://stream.srg-ssr.ch/m/drs1/mp3_128")
     }
     
     @IBAction func playRadioSrf2(_ sender: NSMenuItem) {
-        avPlayer = AVPlayer.init(url: NSURL(string: "http://stream.srg-ssr.ch/m/drs2/mp3_128")! as URL)
-        avPlayer.play()
+        playRadio(radioUrl: "http://stream.srg-ssr.ch/m/drs2/mp3_128")
     }
     
     @IBAction func playRadioSrf3(_ sender: NSMenuItem) {
-        avPlayer = AVPlayer.init(url: NSURL(string: "http://stream.srg-ssr.ch/m/drs3/mp3_128")! as URL)
-        avPlayer.play()
+        playRadio(radioUrl: "http://stream.srg-ssr.ch/m/drs3/mp3_128")
     }
-
     
     @IBAction func playRadioSrf4(_ sender: NSMenuItem) {
-        avPlayer = AVPlayer.init(url: NSURL(string: "http://stream.srg-ssr.ch/m/drs4news/mp3_128")! as URL)
-        avPlayer.play()
+        playRadio(radioUrl: "http://stream.srg-ssr.ch/m/drs4news/mp3_128")
     }
     
     @IBAction func playRadioSrfVirus(_ sender: NSMenuItem) {
-        avPlayer = AVPlayer.init(url: NSURL(string: "http://stream.srg-ssr.ch/m/drsvirus/mp3_128")! as URL)
-        avPlayer.play()
+        playRadio(radioUrl: "http://stream.srg-ssr.ch/m/drsvirus/mp3_128")
     }
     
-    
     @IBAction func playRadioSrfMusikwelle(_ sender: NSMenuItem) {
-        avPlayer = AVPlayer.init(url: NSURL(string: "http://stream.srg-ssr.ch/drsmw/mp3_128.m3u")! as URL)
+        playRadio(radioUrl: "http://stream.srg-ssr.ch/drsmw/mp3_128.m3u")
+    }
+    
+    func playRadio(radioUrl: String)
+    {
+        avPlayer = AVPlayer.init(url: NSURL(string: radioUrl)! as URL)
         avPlayer.play()
     }
     

--- a/Radio SRF Player/StatusMenuController.swift
+++ b/Radio SRF Player/StatusMenuController.swift
@@ -63,7 +63,9 @@ class StatusMenuController: NSObject {
     }
     
     @IBAction func stopPlayback(_ sender: NSMenuItem) {
-        avPlayer.pause();
+        if avPlayer != nil {
+            avPlayer.pause();
+        }
     }
     
 }

--- a/Radio SRF Player/StatusMenuController.swift
+++ b/Radio SRF Player/StatusMenuController.swift
@@ -86,22 +86,19 @@ class StatusMenuController: NSObject {
                 
                 var startCharacterIndex = 0
                 
-                let filler = "  ***  "
-                let displayTrackLength = track.count + filler.count
-                let displayTrack = track + filler + track
+                let filler = "  ***  " // string that is displayed before the track repeats
+                let displayTrackLength = track.count + filler.count // after this count of chars we have to repeat the track title
+                let displayTrack = track + filler + track // attaching the track string to simplify code
                 
                 timerTrackDisplay = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true) {
                     _ in DispatchQueue.main.async {
                         
-                        if startCharacterIndex >= displayTrackLength
-                        {
+                        if startCharacterIndex >= displayTrackLength {
                             startCharacterIndex = 0
                         }
                         
-                        let endCharacterIndex = startCharacterIndex + 9 //display 9 chars at once
+                        let endCharacterIndex = startCharacterIndex + 9 // display 9 chars at once
                         let range = startCharacterIndex..<endCharacterIndex
-                        
-                        
                         let shortenedTrack = String(displayTrack[range])
                         
                         self.statusItem.title = shortenedTrack


### PR DESCRIPTION
## Description

Added a title in the status menu bar. If a title of the radio or the song title exists it appears as a marquee text in the status menu bar. The text repeats after a filler string is shown. I choose " *** " as the filler string, but it's exchangeable.

For this functionality, I've added an observer on the timed metadata of the avPlayer. The timer shifts the texts one character to the left every 0.2 seconds. I've limited the displayed number of characters to 9, because the space is limited and a higher number causes problems with the icon moving back and forth.
The extension is needed. Otherwise, some text with special chars won't be displayed in the status menu bar.